### PR TITLE
Update to slack-github

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,10 +47,11 @@ app.post('/', function(req, res) {
   /* works only, if url config var is there */
   if(url)
   {
+    console.log("Responding to event '%s'", req.headers['x-github-event'])
     if (req.headers['x-github-event'] === 'ping') {
       return res.status(200).json({value: 'pong'});
     }
-    
+
     var options = {};
     options.url = url;
     options.method = 'POST';

--- a/app.js
+++ b/app.js
@@ -47,6 +47,10 @@ app.post('/', function(req, res) {
   /* works only, if url config var is there */
   if(url)
   {
+    if (req.headers['x-github-event'] === 'ping') {
+      return res.status(200).json({value: 'pong'});
+    }
+    
     var options = {};
     options.url = url;
     options.method = 'POST';

--- a/app.js
+++ b/app.js
@@ -23,8 +23,7 @@ var url = process.env.URL;
 var generateMessage = function(req) {
   var result = '';
 
-  var body = req.body;
-  var data = JSON.parse(body.payload);
+  var data = req.body;
 
   for(var i=0;i<data.commits.length;i++)
   {
@@ -60,13 +59,14 @@ app.post('/', function(req, res) {
     options.body = {};
     if(channel) {options.body['channel'] = '#'+ channel +'';}
     if(username) {options.body['username'] = ''+ username +'';}
+    console.log("Would be sending message '%s'", generateMessage(req));
     options.body['text'] = generateMessage(req);
 
     options.json = true;
 
-    request(options, function (err, res, body) {
-      var headers = res.headers;
-      var statusCode = res.statusCode;
+    request(options, function (err, response, body) {
+      var headers = response.headers;
+      var statusCode = response.statusCode;
       res.send(statusCode);
     });
   }


### PR DESCRIPTION
Parsing req.body was causing an exception because req.body was already a JSON object.

The payload was not located in a body.payload property, so data was set to directly be req.body.

The app was not responding to ping events, so a pong response was added specifically for this event. I didn't do extensive testing to see if this was absolutely necessary, so that part may be able to be left out. I don't see it as hurting anything to leave it in place.

Node was getting confused as to which 'res' to use in the callback for Request, so the callback's 'res' was renamed to 'response' to eliminate the confusion.

Adds some simple logging messages to indicate what event is being responded to as well as what message is generated for the IRC channel.
